### PR TITLE
se elimina el uso de public en las referencias a imagenes

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -7,7 +7,7 @@ const Footer = () => {
                         <div className=" ml-8 md:ml-16">
                             <a href="/">
                                 <img
-                                    src="../public/img/Identidad_Aprin.png"
+                                    src="../img/Identidad_Aprin.png"
                                     alt="Logo"
                                     className="w-40 h-28 md:h-24 xl:h-28"
                                 />

--- a/src/components/Formulario.jsx
+++ b/src/components/Formulario.jsx
@@ -230,7 +230,7 @@ const Formulario = () => {
         </div>
       </div>
       <a href="https://wa.me/5491154555573" target="_blank" rel="noopener noreferrer">
-        <img src="../public/img/whatsapp_logo.svg" loading="lazy" alt="WhatsApp Logo" className="fixed bottom-12 right-12 z-50 w-16 h-auto"></img>
+        <img src="../img/whatsapp_logo.svg" loading="lazy" alt="WhatsApp Logo" className="fixed bottom-12 right-12 z-50 w-16 h-auto"></img>
       </a>
     </form>
   );

--- a/src/components/Servicios.jsx
+++ b/src/components/Servicios.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
-import ImgPlanta from '/public/img/Frame-planta.png';
-import ImgServicios from '/public/img/servicio.jpg';
+import ImgPlanta from '/img/Frame-planta.png';
+import ImgServicios from '/img/servicio.jpg';
 
 
 const Servicios = () => {

--- a/src/components/SobreNosotros.jsx
+++ b/src/components/SobreNosotros.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import ImgFirst from '/public/img/redes-inform-4.jpg';
-import ImgSecond from '/public/img/desarrollo-web-a-medida-4.png';
+import ImgSecond from '/img/desarrollo-web-a-medida-4.png';
 
 const SobreNosotros = () => {
     return (


### PR DESCRIPTION
En vez de poner /public/img/<imagen> para referenciar a las imagenes, se pone /img/<imagen>